### PR TITLE
K8s API Version Overrides

### DIFF
--- a/.changeset/early-bees-think.md
+++ b/.changeset/early-bees-think.md
@@ -1,5 +1,5 @@
 ---
-'@backstage/plugin-kubernetes-backend': minor
+'@backstage/plugin-kubernetes-backend': patch
 ---
 
 Added apiVersionOverrides config to allow for specifying api versions to use for kubernetes objects

--- a/.changeset/early-bees-think.md
+++ b/.changeset/early-bees-think.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-kubernetes-backend': minor
+---
+
+Added apiVersionOverrides config to allow for specifying api versions to use for kubernetes objects

--- a/docs/features/kubernetes/configuration.md
+++ b/docs/features/kubernetes/configuration.md
@@ -225,6 +225,13 @@ Overrides for the API versions used to make requests for the corresponding
 objects. If using a legacy Kubernetes version, you may use this config to
 override the default API versions to ones that are supported by your cluster.
 
+```yaml
+---
+kubernetes:
+  apiVersionOverrides:
+    cronjobs: 'v1beta1'
+```
+
 ### Role Based Access Control
 
 The current RBAC permissions required are read-only cluster wide, for the

--- a/docs/features/kubernetes/configuration.md
+++ b/docs/features/kubernetes/configuration.md
@@ -219,6 +219,12 @@ The custom resource's apiVersion.
 
 The plural representing the custom resource.
 
+### `apiVersionOverrides` (optional)
+
+Overrides for the API versions used to make requests for the corresponding
+objects. If using a legacy Kubernetes version, you may use this config to
+override the default API versions to ones that are supported by your cluster.
+
 ### Role Based Access Control
 
 The current RBAC permissions required are read-only cluster wide, for the

--- a/docs/features/kubernetes/configuration.md
+++ b/docs/features/kubernetes/configuration.md
@@ -225,12 +225,19 @@ Overrides for the API versions used to make requests for the corresponding
 objects. If using a legacy Kubernetes version, you may use this config to
 override the default API versions to ones that are supported by your cluster.
 
+Example:
+
 ```yaml
 ---
 kubernetes:
   apiVersionOverrides:
     cronjobs: 'v1beta1'
 ```
+
+For more information on which API versions are supported by your cluster, please
+view the Kubernetes API docs for your Kubernetes version (e.g.
+[API Groups for v1.22](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.22/#-strong-api-groups-strong-)
+)
 
 ### Role Based Access Control
 

--- a/plugins/kubernetes-backend/schema.d.ts
+++ b/plugins/kubernetes-backend/schema.d.ts
@@ -63,6 +63,13 @@ export interface Config {
       apiVersion: string;
       plural: string;
     }>;
+
+    /**
+     * (Optional) API Version Overrides
+     * If set, the specified api version will be used to make requests for the corresponding object.
+     * If running a legacy Kubernetes version, you may use this to override the default api versions
+     * that are not supported in your cluster.
+     */
     apiVersionOverrides?: {
       pods?: string;
       services?: string;
@@ -70,6 +77,8 @@ export interface Config {
       deployments?: string;
       replicasets?: string;
       horizontalpodautoscalers?: string;
+      cronjobs?: string;
+      jobs?: string;
       ingresses?: string;
     };
   };

--- a/plugins/kubernetes-backend/schema.d.ts
+++ b/plugins/kubernetes-backend/schema.d.ts
@@ -63,5 +63,14 @@ export interface Config {
       apiVersion: string;
       plural: string;
     }>;
+    apiVersionOverrides?: {
+      pods?: string;
+      services?: string;
+      configmaps?: string;
+      deployments?: string;
+      replicasets?: string;
+      horizontalpodautoscalers?: string;
+      ingresses?: string;
+    };
   };
 }

--- a/plugins/kubernetes-backend/schema.d.ts
+++ b/plugins/kubernetes-backend/schema.d.ts
@@ -80,6 +80,6 @@ export interface Config {
       cronjobs?: string;
       jobs?: string;
       ingresses?: string;
-    };
+    } & { [pluralKind: string]: string };
   };
 }

--- a/plugins/kubernetes-backend/src/service/KubernetesBuilder.ts
+++ b/plugins/kubernetes-backend/src/service/KubernetesBuilder.ts
@@ -259,7 +259,7 @@ export class KubernetesBuilder {
       objectTypesToFetch = objectTypesToFetch ?? DEFAULT_OBJECTS;
 
       for (const obj of objectTypesToFetch) {
-        if (apiVersionOverrides.getOptionalString(obj.objectType)) {
+        if (apiVersionOverrides.has(obj.objectType)) {
           obj.apiVersion = apiVersionOverrides.getString(obj.objectType);
         }
       }

--- a/plugins/kubernetes-backend/src/service/KubernetesBuilder.ts
+++ b/plugins/kubernetes-backend/src/service/KubernetesBuilder.ts
@@ -243,6 +243,10 @@ export class KubernetesBuilder {
       'kubernetes.objectTypes',
     ) as KubernetesObjectTypes[];
 
+    const apiVersionOverrides = this.env.config.getOptionalConfig(
+      'kubernetes.apiVersionOverrides',
+    );
+
     let objectTypesToFetch;
 
     if (objectTypesToFetchStrings) {
@@ -250,6 +254,17 @@ export class KubernetesBuilder {
         objectTypesToFetchStrings.includes(obj.objectType),
       );
     }
+
+    if (apiVersionOverrides) {
+      objectTypesToFetch = objectTypesToFetch ?? DEFAULT_OBJECTS;
+
+      for (const obj of objectTypesToFetch) {
+        if (apiVersionOverrides.getOptionalString(obj.objectType)) {
+          obj.apiVersion = apiVersionOverrides.getString(obj.objectType);
+        }
+      }
+    }
+
     return objectTypesToFetch;
   }
 }


### PR DESCRIPTION
## Hey, I just made a Pull Request!

<!-- Please describe what you added, and add a screenshot if possible.
     That makes it easier to understand the change so we can :shipit: faster. -->

Was playing around with this to override the default api versions for the objects... wondering what people think. Not sure if there are significant differences between the `v1beta1` and `v1` apis for this to break anything though. Open to other solutions/thoughts on this!

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [ ] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
